### PR TITLE
fix: run server only when executed directly

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -80,11 +80,13 @@ app.use((error, req, res, next) => {
   });
 });
 
-// Iniciar servidor
-app.listen(PORT, () => {
-  console.log(`🚀 Servidor corriendo en puerto ${PORT}`);
-  console.log(`📚 Documentación disponible en http://localhost:${PORT}/docs`);
-  console.log(`🔍 API base en http://localhost:${PORT}/api`);
-});
+// Iniciar servidor solo si este archivo es ejecutado directamente
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`🚀 Servidor corriendo en puerto ${PORT}`);
+    console.log(`📚 Documentación disponible en http://localhost:${PORT}/docs`);
+    console.log(`🔍 API base en http://localhost:${PORT}/api`);
+  });
+}
 
 module.exports = app;


### PR DESCRIPTION
## Summary
- prevent Express server from listening when imported

## Testing
- `npm test` *(fails: Cannot find module 'supertest' / 'ajv-formats')*


------
https://chatgpt.com/codex/tasks/task_e_689aa80052e4832db502b4c19797608a