### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "compression": "^1.7.4",
     "dotenv": "^16.3.1",
     "ajv": "^8.12.0",
-    "moment": "^2.29.4"
+    "moment": "^2.29.4",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const compression = require('compression');
 const path = require('path');
+const rateLimit = require('express-rate-limit');
 
 // Importar rutas
 const logiasRoutes = require('./api/routes/logias');
@@ -16,6 +17,12 @@ const estadisticasRoutes = require('./api/routes/estadisticas');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+// Limitador de solicitudes para rutas que acceden al sistema de archivos
+const docsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutos
+  max: 100, // máximo 100 solicitudes por ventana
+});
 
 // Middlewares de seguridad y optimización
 app.use(helmet());
@@ -50,7 +57,7 @@ app.get('/', (req, res) => {
 });
 
 // Ruta de documentación
-app.get('/docs', (req, res) => {
+app.get('/docs', docsLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, '../public/docs.html'));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/hackhit/logias/security/code-scanning/2](https://github.com/hackhit/logias/security/code-scanning/2)

To fix the issue, we should introduce an HTTP rate‑limiting middleware and apply it to the `/docs` route (or globally, but minimally to the route that does the file access). The standard approach in Express is to use a well‑known library such as `express-rate-limit`, configure a limiter (window and max requests), and plug it into the middleware chain before the handler that calls `sendFile`.

In this file (`src/server.js`), we can:  
1) Add a `require('express-rate-limit')` statement near the other `require` calls.  
2) Create a limiter instance, for example allowing a reasonable number of requests per 15‑minute window.  
3) Apply that limiter specifically to `GET /docs` by adding it as a middleware argument to `app.get('/docs', ...)`. This avoids changing behavior of other endpoints while satisfying the rule for the file‑serving route.

Concretely:
- Above the middleware configuration, define something like `const rateLimit = require('express-rate-limit');` and `const docsLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 100 });`.
- Change the `/docs` route from `app.get('/docs', (req, res) => { ... });` to `app.get('/docs', docsLimiter, (req, res) => { ... });`.
No other functionality needs to change: the handler still returns the same file, but now requests hitting `/docs` are throttled.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
